### PR TITLE
Fixed transform animation bug for home section

### DIFF
--- a/scripts/animation.js
+++ b/scripts/animation.js
@@ -13,6 +13,19 @@
                 $body.removeClass('is-preload')
             }, 100)
         }
+
+        if (location.hash === '' ||	location.hash === '#') {
+            $home.addClass('onSectionActive')
+            window.setTimeout(function() {
+                $home.removeClass('onSectionActive')
+            }, 500)
+
+            // Prevent default
+            event.preventDefault()
+            event.stopPropagation()
+
+            $wrapper._hide()
+        }
     })
 
     // Fix: Flexbox min-height bug on IE. 
@@ -287,7 +300,7 @@
 	// Hide sections
     $sections.hide()
 
-    // Initial section
+    // Initialize wrapper show function when condition results to true
     if (location.hash !== '' &&	location.hash !== '#') {
         $window.on('load', function() {
             $wrapper._show(location.hash.substr(1))


### PR DESCRIPTION
# Description

On page load, the home section was not rotating from 50 degrees to 0 degrees on the x axis. 

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I fixed the transform animation bug for the home section by placing code to add and remove the class "onSectionActive" for the home section within a window.on load function call in the animation.js file. As a result, the home section now transforms on the web page correctly when the website is refreshed or loaded.

```
$window.on('load', function() {
  if (!$body.hasClass('is-section-visible')) {
    window.setTimeout(function() {
      $body.removeClass('is-preload')
    }, 100)
  }

  if (location.hash === '' || location.hash === '#') {
    $home.addClass('onSectionActive')
     window.setTimeout(function() {
       $home.removeClass('onSectionActive')
     }, 500)

    // Prevent default
    event.preventDefault()
    event.stopPropagation()

     $wrapper._hide()
  }
})
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code